### PR TITLE
changes for v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ None
 ## [WIP] 0.2.0 / 2017-December-??
 
 - Set Home/End keys to behave as beginning/end of line respectively
+  - Let Home key alternate between beginning of line and first column
 - Enable column number display for every line in all buffers
 - Display whitespace with highlight on exceeding width threshold
 - Compress multi-whitespace lines in one keystroke (Ctrl+Alt+Space)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@
 - [Todo] Add inf-clojure (Inferior Clojure mode)
 
 
-## [WIP] 0.2.0 / 2017-December-??
+## 0.2.0 / 2017-December-30
 
 - Set Home/End keys to behave as beginning/end of line respectively
   - Let Home key alternate between beginning of line and first column
 - Enable column number display for every line in all buffers
 - Display whitespace with highlight on exceeding width threshold
-- Compress multi-whitespace lines in one keystroke (Ctrl+Alt+Space)
+- Shrink multi-whitespace lines in one keystroke (Ctrl+Alt+Space)
 - Add markdown mode for markdown files
 - Neotree file browser (F8: Toggle display, F9: Refresh content)
 - Enable strictly 2-space auto indentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Neotree file browser (F8: Toggle display, F9: Refresh content)
 - Enable strictly 2-space auto indentation
 - Close buffer and window in one keystroke (Cmd+w)
+- Save and restore window layout by default
 - Pin Clojure extensions to stable versions
   - Cider
   - Clj-refactor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## TODO
 
-None
+- [Todo] Add inf-clojure (Inferior Clojure mode)
 
 
 ## [WIP] 0.2.0 / 2017-December-??

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,20 @@
 
 ## TODO
 
-- [Todo] Set Home/End keys to behave as beginning/end of line respectively
-- [Todo] Enable column number display for every line in all buffers
-- [Todo] Display whitespace with highlight on exceeding width threshold
-- [Todo] Compress multi-whitespace lines in one keystroke (Ctrl+Alt+Space)
-- [Todo] Add markdown mode for markdown files
-- [Todo] Neotree file browser (F8: Toggle display, F9: Refresh content)
-- [Todo] Enable strictly 2-space auto indentation
-- [Todo] Close buffer and window in one keystroke (Cmd+w)
+None
+
+
+## [WIP] 0.2.0 / 2017-December-??
+
+- Set Home/End keys to behave as beginning/end of line respectively
+- Enable column number display for every line in all buffers
+- Display whitespace with highlight on exceeding width threshold
+- Compress multi-whitespace lines in one keystroke (Ctrl+Alt+Space)
+- Add markdown mode for markdown files
+- Neotree file browser (F8: Toggle display, F9: Refresh content)
+- Enable strictly 2-space auto indentation
+- Close buffer and window in one keystroke (Cmd+w)
+
 
 ## 0.1.0 / 2017-December-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Enable strictly 2-space auto indentation
 - Close buffer and window in one keystroke (Cmd+w)
 - Save and restore window layout by default
+- Enable buffer tabs by default
 - Pin Clojure extensions to stable versions
   - Cider
   - Clj-refactor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ None
 - Neotree file browser (F8: Toggle display, F9: Refresh content)
 - Enable strictly 2-space auto indentation
 - Close buffer and window in one keystroke (Cmd+w)
+- Pin Clojure extensions to stable versions
+  - Cider
+  - Clj-refactor
 
 
 ## 0.1.0 / 2017-December-29

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Based on https://gitlab.com/nilenso/dotemacs and some additions.
 ## Installation
 
 0. Install Emacs
-  - OSX: https://emacsformacosx.com/ or `brew install emacs --with-cocoa`
-  - Windows: Download from https://www.gnu.org/software/emacs/download.html
-  - Linux: Use the OS package manager
+    - OSX: https://emacsformacosx.com/ or `brew install emacs --with-cocoa`
+    - Windows: Download from https://www.gnu.org/software/emacs/download.html
+    - Linux: Use the OS package manager
 1. Backup and remove any existing `~/.emacs.d` directory.
 2. Run `git clone https://github.com/kumarshantanu/dotemacs ~/.emacd.d`
 3. Starts Emacs and let it download and setup everything.

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Based on https://gitlab.com/nilenso/dotemacs and some additions.
 ## Installation
 
 0. Install Emacs
-  1. OSX: https://emacsformacosx.com/ or `brew install emacs --with-cocoa`
-  2. Windows: Download from https://www.gnu.org/software/emacs/download.html
-  3. Linux: Use the OS package manager
+  - OSX: https://emacsformacosx.com/ or `brew install emacs --with-cocoa`
+  - Windows: Download from https://www.gnu.org/software/emacs/download.html
+  - Linux: Use the OS package manager
 1. Backup and remove any existing `~/.emacs.d` directory.
 2. Run `git clone https://github.com/kumarshantanu/dotemacs ~/.emacd.d`
 3. Starts Emacs and let it download and setup everything.

--- a/README.md
+++ b/README.md
@@ -23,10 +23,12 @@ Create a file `init-user.el` file with custom changes.
 
 ## Usage
 
-Projectile help page: `C-c p C-h`
+Beginning of non-whitespace in current line: `M-m` (`'back-to-indentation`)
 
 Shrink contiguous whitespace into single space: `C-M-SPC` (Ctrl+Alt+Space)
 
 Show/hide NeoTree: `F8` (`F9` to refresh)
 
 Close current buffer and window: `s-w` (Cmd+w)
+
+Projectile help page: `C-c p C-h`

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If you do not want whitespace markers, put the following to `init-user.el`:
 
 Shrink contiguous whitespace into single space: `C-M-SPC` (Ctrl+Alt+Space)
 
-Show/hide NeoTree: `F8` (`F9` to refresh)
+NeoTree: `F8` Show/hide, `F9` Refresh, Doc: https://github.com/jaypei/emacs-neotree
 
 Close current buffer and window: `s-w` (Cmd+w)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A lean setup for Clojurians.
 
-Based on https://gitlab.com/nilenso/dotemacs and some additions.
+Based on https://gitlab.com/nilenso/dotemacs and some additions and changes.
 
 
 ## Installation
@@ -36,3 +36,25 @@ Show/hide NeoTree: `F8` (`F9` to refresh)
 Close current buffer and window: `s-w` (Cmd+w)
 
 Projectile help page: `C-c p C-h`
+
+### CIDER/nREPL connection
+
+To connect via [Cider](https://cider.readthedocs.io/en/latest/) add the following
+entry (update versions as appropriate) in `~/.lein/profiles.clj` file:
+
+```clojure
+:repl {:plugins [[cider/cider-nrepl "0.16.0"]
+                 [refactor-nrepl    "2.3.1"]]}
+```
+
+**Note:**
+This entry has `:repl` as the key, so that it is used only with a REPL,
+and does not slow down other Leiningen tasks.
+
+If the file `~/.lein/profiles.clj` does not exist already, then create one with the
+following content (update versions as appropriate):
+
+```clojure
+{:repl {:plugins [[cider/cider-nrepl "0.16.0"]
+                  [refactor-nrepl    "2.3.1"]]}}
+```

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ Based on https://gitlab.com/nilenso/dotemacs and some additions.
 
 Create a file `init-user.el` file with custom changes.
 
+If you do not want whitespace markers, put the following to `init-user.el`:
+
+```clojure
+(global-whitespace-mode 0)
+```
+
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -18,12 +18,18 @@ Based on https://gitlab.com/nilenso/dotemacs and some additions and changes.
 
 ## Customization
 
-Create a file `init-user.el` file with custom changes.
+Create a file `init-user.el` file with any custom changes.
 
-If you do not want whitespace markers, put the following to `init-user.el`:
+To disable whitespace markers, put the following to `init-user.el`:
 
 ```elisp
 (global-whitespace-mode 0)
+```
+
+To stop restoring window layout, put the following to `init-user.el`:
+
+```elisp
+(desktop-save-mode 0)
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ Create a file `init-user.el` file with custom changes.
 
 ## Usage
 
-Beginning of non-whitespace in current line: `M-m` (`'back-to-indentation`)
-
 Shrink contiguous whitespace into single space: `C-M-SPC` (Ctrl+Alt+Space)
 
 Show/hide NeoTree: `F8` (`F9` to refresh)

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Based on https://gitlab.com/nilenso/dotemacs and some additions.
 ## Installation
 
 0. Install Emacs
-    - OSX: https://emacsformacosx.com/ or `brew install emacs --with-cocoa`
+    - OSX: https://emacsformacosx.com/ or run `brew install emacs --with-cocoa`
     - Windows: Download from https://www.gnu.org/software/emacs/download.html
     - Linux: Use the OS package manager
 1. Backup and remove any existing `~/.emacs.d` directory.
-2. Run `git clone https://github.com/kumarshantanu/dotemacs ~/.emacd.d`
+2. Run `git clone https://github.com/kumarshantanu/dotemacs.git ~/.emacd.d`
 3. Starts Emacs and let it download and setup everything.
 
 

--- a/README.md
+++ b/README.md
@@ -18,18 +18,17 @@ Based on https://gitlab.com/nilenso/dotemacs and some additions and changes.
 
 ## Customization
 
-Create a file `init-user.el` file with any custom changes.
-
-To disable whitespace markers, put the following to `init-user.el`:
+Create a file `init-user.el` file with any custom changes, e.g. the following:
 
 ```elisp
+;; Disable whitespace markers
 (global-whitespace-mode 0)
-```
 
-To stop restoring window layout, put the following to `init-user.el`:
-
-```elisp
+;; Do not save/restore window layout
 (desktop-save-mode 0)
+
+;; Disable buffer tabs
+(tabbar-mode 0)
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ Based on https://gitlab.com/nilenso/dotemacs and some additions.
 3. Starts Emacs and let it download and setup everything.
 
 
+## Customization
+
+Create a file `init-user.el` file with custom changes.
+
+
 ## Usage
 
 Projectile help page: `C-c p C-h`
+
+Shrink contiguous whitespace into single space: `C-M-SPC` (Ctrl+Alt+Space)
+
+Show/hide NeoTree: `F8` (`F9` to refresh)
+
+Close current buffer and window: `s-w` (Cmd+w)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Create a file `init-user.el` file with custom changes.
 
 If you do not want whitespace markers, put the following to `init-user.el`:
 
-```clojure
+```elisp
 (global-whitespace-mode 0)
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# dotemacs
+# dot-emacs
 
 A lean setup for Clojurians.
 
@@ -12,7 +12,7 @@ Based on https://gitlab.com/nilenso/dotemacs and some additions and changes.
     - Windows: Download from https://www.gnu.org/software/emacs/download.html
     - Linux: Use the OS package manager
 1. Backup and remove any existing `~/.emacs.d` directory.
-2. Run `git clone https://github.com/kumarshantanu/dotemacs.git ~/.emacd.d`
+2. Run `git clone https://github.com/kumarshantanu/dot-emacs.git ~/.emacd.d`
 3. Starts Emacs and let it download and setup everything.
 
 

--- a/init.el
+++ b/init.el
@@ -198,7 +198,7 @@
 
 ;; Enable whitespace mode
 (setq whitespace-line-column 120)
-(setq global-whitespace-mode t)
+(global-whitespace-mode 1)
 
 (use-package crux
   :ensure t)

--- a/init.el
+++ b/init.el
@@ -200,8 +200,13 @@
 (setq whitespace-line-column 120)
 (setq global-whitespace-mode t)
 
+(use-package crux
+  :ensure t)
+(require 'crux)
+(global-set-key [remap move-beginning-of-line] #'crux-move-beginning-of-line)
+
 ;; Set Home and End key bindings
-(global-set-key (kbd "<home>") 'beginning-of-line)
+(global-set-key (kbd "<home>") 'move-beginning-of-line) ; was 'beginning-of-line
 (global-set-key (kbd "<end>") 'end-of-line)
 
 ;; C-M-space should remove multiple whitespace lines into a single blank

--- a/init.el
+++ b/init.el
@@ -261,6 +261,9 @@
 ;; Kill window and buffer in one keystroke
 (global-set-key (kbd "s-w") 'kill-buffer-and-window)
 
+;; Save and restore window layout
+(desktop-save-mode 1)
+
 ;; ----- Added by Shantanu till this point -----
 
 

--- a/init.el
+++ b/init.el
@@ -264,6 +264,43 @@
 ;; Save and restore window layout
 (desktop-save-mode 1)
 
+;; buffer tabs
+(use-package tabbar
+  :ensure t)
+(require 'tabbar)
+(set-face-attribute
+   'tabbar-default nil
+    :background "gray60")
+(set-face-attribute
+   'tabbar-unselected nil
+    :background "gray85"
+     :foreground "gray30"
+      :box nil)
+(set-face-attribute
+   'tabbar-selected nil
+    :background "#f2f2f6"
+     :foreground "black"
+      :box nil)
+(set-face-attribute
+   'tabbar-button nil
+    :box '(:line-width 1 :color "gray72" :style released-button))
+(set-face-attribute
+   'tabbar-separator nil
+    :height 0.7)
+(tabbar-mode 1)
+;(tabbar-mode)
+(global-set-key [(control shift tab)] 'tabbar-backward)
+(global-set-key [(control tab)]       'tabbar-forward)
+
+;; tabbar ruler
+(use-package tabbar-ruler
+  :ensure t)
+(require 'tabbar-ruler)
+(setq tabbar-ruler-global-tabbar 't) ; If you want tabbar
+;(setq tabbar-ruler-global-ruler 't) ; if you want a global ruler
+;(setq tabbar-ruler-popup-menu 't) ; If you want a popup menu.
+;(setq tabbar-ruler-popup-toolbar 't) ; If you want a popup toolbar
+
 ;; ----- Added by Shantanu till this point -----
 
 

--- a/init.el
+++ b/init.el
@@ -199,7 +199,6 @@
 ;; Enable whitespace mode
 (setq whitespace-line-column 120)
 (setq global-whitespace-mode t)
-;(global-whitespace-mode 1)
 
 ;; Set Home and End key bindings
 (global-set-key (kbd "<home>") 'beginning-of-line)

--- a/init.el
+++ b/init.el
@@ -129,6 +129,7 @@
 ;; Cider integrates a Clojure buffer with a REPL
 (use-package cider
   :ensure t
+  :pin melpa-stable
   :init
   (setq cider-repl-pop-to-buffer-on-connect t
         cider-show-error-buffer t
@@ -158,6 +159,7 @@
 ;; Adds some niceties/refactoring support
 (use-package clj-refactor
   :ensure t
+  :pin melpa-stable
   :config
   (add-hook 'clojure-mode-hook
             (lambda ()

--- a/init.el
+++ b/init.el
@@ -1,4 +1,4 @@
-;; A minimial setup for Clojurians
+;; A lean setup for Clojurians
 
 
 (require 'package)
@@ -189,6 +189,74 @@
 
 ;; Magit: The only git interface you'll ever need
 (use-package magit :ensure t)
+
+
+;; ----- Added by Shantanu this point onward -----
+
+;; Enable column numbers
+(setq column-number-mode t)
+
+;; Enable whitespace mode
+(setq whitespace-line-column 120)
+(setq global-whitespace-mode t)
+;(global-whitespace-mode 1)
+
+;; Set Home and End key bindings
+(global-set-key (kbd "<home>") 'beginning-of-line)
+(global-set-key (kbd "<end>") 'end-of-line)
+
+;; C-M-space should remove multiple whitespace lines into a single blank
+;; character
+(defun multi-line-just-one-space (&optional n)
+  "Multi-line version of just-one-space: Delete all
+  spaces, tabs and newlines around point,
+  leaving one space (or N spaces)."
+  (interactive "*p")
+  (let ((orig-pos (point)))
+    (skip-chars-backward " \t\n")
+    (constrain-to-field nil orig-pos)
+    (dotimes (i (or n 1))
+      (if (= (following-char) ?\s)
+    (forward-char 1)
+  (insert ?\s)))
+    (delete-region
+     (point)
+     (progn
+       (skip-chars-forward " \t\n")
+       (constrain-to-field nil orig-pos t)))))
+(global-set-key (kbd "C-M-SPC") 'multi-line-just-one-space)
+
+;; Strictly 2-space indentation
+(setq-default indent-tabs-mode nil)
+(setq clojure-defun-style-default-indent t)
+(setq clojure-indent-style :always-indent)
+(eval-after-load "clojure-mode"
+   '(progn
+      (define-clojure-indent
+        (:require 0)
+        (:import 0))))
+
+;; markdown
+(use-package markdown-mode
+  :ensure t
+  :commands (markdown-mode gfm-mode)
+  :mode (("README\\.md\\'" . gfm-mode)
+         ("\\.md\\'" . markdown-mode)
+         ("\\.markdown\\'" . markdown-mode))
+  :init (setq markdown-command "multimarkdown"))
+
+;; neotree
+(use-package neotree
+  :ensure t)
+(require 'neotree)
+(global-set-key [f8] 'neotree-toggle)
+(global-set-key [f9] 'neotree-refresh)
+
+;; Kill window and buffer in one keystroke
+(global-set-key (kbd "s-w") 'kill-buffer-and-window)
+
+;; ----- Added by Shantanu till this point -----
+
 
 ;; User customizations
 (when (file-exists-p "~/.emacs.d/init-user.el")


### PR DESCRIPTION
- Set Home/End keys to behave as beginning/end of line respectively
  - Let Home key alternate between beginning of line and first column
- Enable column number display for every line in all buffers
- Display whitespace with highlight on exceeding width threshold
- Shrink multi-whitespace lines in one keystroke (Ctrl+Alt+Space)
- Add markdown mode for markdown files
- Neotree file browser (F8: Toggle display, F9: Refresh content)
- Enable strictly 2-space auto indentation
- Close buffer and window in one keystroke (Cmd+w)
- Save and restore window layout by default
- Enable buffer tabs by default
- Pin Clojure extensions to stable versions
  - Cider
  - Clj-refactor